### PR TITLE
Add to deposit is adding in the tot amount, rather than replacing amount

### DIFF
--- a/contracts/facets/Deposit.sol
+++ b/contracts/facets/Deposit.sol
@@ -264,7 +264,7 @@ contract Deposit is Pausable, IDeposit{
 
 		activeDeposits.market[num] = _market;
 		activeDeposits.commitment[num] = _commitment;
-		activeDeposits.amount[num] = _amount;
+		activeDeposits.amount[num] += _amount;
 		activeDeposits.savingsInterest[num] = yield.accruedYield;
 	}
 


### PR DESCRIPTION
Bug: In the addToDeposit function call / _processDeposit() in deposit.sol, activeDeposits.amount = _amount; where instead, it must be activeDeposits.amount += _amount; as the active deposits struct must update the existing deposit record by adding the add-on amount.